### PR TITLE
Fixed GCC 7 compilation warnings

### DIFF
--- a/core/contactlist.cpp
+++ b/core/contactlist.cpp
@@ -607,7 +607,7 @@ void ContactList::sort(ContactList::SortType sortType)
             c.actualSortString = c.fullName;
             break;
         case SortByNick:
-            c.actualSortString = c.nickName;
+            c.actualSortString = c.nickName; // fall through
         case SortByGroup:
             c.actualSortString = c.groups.join(", ");
         }

--- a/core/formats/files/csvfile.cpp
+++ b/core/formats/files/csvfile.cpp
@@ -121,7 +121,7 @@ bool CSVFile::importRecords(const QString &url, ContactList &list, bool append)
                     row << val;
                     val.clear();
                     break;
-                }
+                } // fall through
             case 0:
             default:
                 val += c;


### PR DESCRIPTION
```
../core/contactlist.cpp: In member function ‘void ContactList::sort(ContactList::SortType)’:
../core/contactlist.cpp:610:32: warning: this statement may fall through [-Wimplicit-fallthrough=]
             c.actualSortString = c.nickName;
             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
../core/contactlist.cpp:611:9: note: here
         case SortByGroup:
         ^~~~
```

```
../core/formats/files/csvfile.cpp: In member function ‘virtual bool CSVFile::importRecords(const QString&, ContactList&, bool)’:
../core/formats/files/csvfile.cpp:120:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
                 if (!inQuotes) {
                 ^~
../core/formats/files/csvfile.cpp:125:13: note: here
             case 0:
             ^~~~
```