### PR TITLE
Complete CMake update

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+cmake_minimum_required(VERSION 3.5)
+
+add_subdirectory(quazip/quazip)
+
+if (WITH_NETWORK)
+    add_subdirectory(qwebdavlib/qwebdavlib)
+endif ()

--- a/3rdparty/quazip/quazip/CMakeLists.txt
+++ b/3rdparty/quazip/quazip/CMakeLists.txt
@@ -1,31 +1,51 @@
-# set all include directories for in and out of source builds
-include_directories(
-	${CMAKE_CURRENT_SOURCE_DIR}
-	${CMAKE_CURRENT_BINARY_DIR}
-	${ZLIB_INCLUDE_DIRS}
-)
 
-file(GLOB SRCS "*.c" "*.cpp")
-file(GLOB PUBLIC_HEADERS "*.h")
+cmake_minimum_required(VERSION 3.5)
 
-# Must be added to enable export macro
-ADD_DEFINITIONS(-DQUAZIP_BUILD)
+project(quazip VERSION 1.0.0 LANGUAGES C CXX)
 
-qt_wrap_cpp(MOC_SRCS ${PUBLIC_HEADERS})
-set(SRCS ${SRCS} ${MOC_SRCS})
+add_library(quazip_static STATIC)
+set_target_properties(quazip_static PROPERTIES AUTOMOC ON)
+target_link_libraries(quazip_static PUBLIC Qt::Core libzip::zip ZLIB::ZLIB)
+target_include_directories(quazip_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_definitions(quazip_static PRIVATE QUAZIP_BUILD)
 
-add_library(${QUAZIP_LIB_TARGET_NAME} SHARED ${SRCS})
-add_library(quazip_static STATIC ${SRCS})
- 
-# Windows uses .lib extension for both static and shared library
-# *nix systems use different extensions for SHARED and STATIC library and by convention both libraries have the same name
-if (NOT WIN32)
-	set_target_properties(quazip_static PROPERTIES OUTPUT_NAME quazip${QUAZIP_LIB_VERSION_SUFFIX})
+target_sources(quazip_static
+    PRIVATE
+    # HEADERS
+    ################
+         crypt.h
+         ioapi.h
+         JlCompress.h
+         quaadler32.h
+         quachecksum32.h
+         quacrc32.h
+         quagzipfile.h
+         quaziodevice.h
+         quazipdir.h
+         quazipfile.h
+         quazipfileinfo.h
+         quazip_global.h
+         quazip.h
+         quazipnewinfo.h
+         unzip.h
+         zip.h
+    # SOURCES
+    ################
+        qioapi.cpp
+        JlCompress.cpp
+        quaadler32.cpp
+        quacrc32.cpp
+        quagzipfile.cpp
+        quaziodevice.cpp
+        quazip.cpp
+        quazipdir.cpp
+        quazipfile.cpp
+        quazipfileinfo.cpp
+        quazipnewinfo.cpp
+        unzip.c
+        zip.c
+ )
+
+if (TARGET ${QT}::Core5Compat)
+    target_link_libraries(quazip_static PUBLIC ${QT}::Core5Compat)
 endif ()
-
-set_target_properties(${QUAZIP_LIB_TARGET_NAME} quazip_static PROPERTIES VERSION 1.0.0 SOVERSION 1 DEBUG_POSTFIX d)
-# Link against ZLIB_LIBRARIES if needed (on Windows this variable is empty)
-target_link_libraries(${QUAZIP_LIB_TARGET_NAME} quazip_static ${QT_QTMAIN_LIBRARY} ${QTCORE_LIBRARIES} ${ZLIB_LIBRARIES})
-
-install(FILES ${PUBLIC_HEADERS} DESTINATION include/quazip${QUAZIP_LIB_VERSION_SUFFIX})
-install(TARGETS ${QUAZIP_LIB_TARGET_NAME} quazip_static LIBRARY DESTINATION ${LIB_DESTINATION} ARCHIVE DESTINATION ${LIB_DESTINATION} RUNTIME DESTINATION ${LIB_DESTINATION})

--- a/3rdparty/qwebdavlib/qwebdavlib/CMakeLists.txt
+++ b/3rdparty/qwebdavlib/qwebdavlib/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+cmake_minimum_required(VERSION 3.5)
+
+add_library(qwebdav STATIC)
+set_target_properties(qwebdav PROPERTIES AUTOMOC ON)
+target_link_libraries(qwebdav PUBLIC Qt::Core Qt::Network Qt::Xml)
+target_include_directories(qwebdav PUBLIC .)
+target_compile_definitions(qwebdav PRIVATE QWEBDAV_LIBRARY)
+
+target_sources(qwebdav
+    PRIVATE
+    # HEADERS
+    ################
+        qwebdav.h
+        qwebdavitem.h
+        qwebdavdirparser.h
+        qnaturalsort.h
+        qwebdav_global.h
+    # SOURCES
+    ################
+        qwebdav.cpp
+        qwebdavitem.cpp
+        qwebdavdirparser.cpp
+        qnaturalsort.cpp
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,191 @@
+################################################################################
+#
+# Options:
+#   REQUEST_QT:STRING   Explicitly specify the required generation of Qt. This
+#                       can be useful if different major versions of Qt are
+#                       installed on the system. Valid values are '4', '5' or
+#                       '6'. If not specified, the build script uses the first
+#                       available major version of Qt, starting the search at
+#                       '4' and ending at '6'.
+#   WITH_CALLS:BOOL
+#   WITH_MESSAGES:BOOL
+#   WITH_NETWORK:BOOL
+#   USE_GPL2:BOOL
+#
+################################################################################
+
+
+cmake_minimum_required(VERSION 3.11)
+
+project(DoubleContact VERSION 0.2.5 LANGUAGES CXX)
+
+option(WITH_CALLS    "" ON)
+option(WITH_MESSAGES "" ON)
+option(USE_GPL2      "" OFF)
+option(WITH_NETWORK  "" OFF)
+
+set(CMAKE_CXX_EXTENSIONS ON)
+set(CMAKE_CXX_STANDARD 11)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+
+# Necessary packages
+find_package(libzip REQUIRED)
+find_package(ZLIB REQUIRED)
+
+
+# What version of Qt are we working with?
+################################################################################
+
+if (NOT ${REQUEST_QT} OR ${REQUEST_QT} EQUAL 4)
+    if (WITH_NETWORK)
+        set(EXTRA_PACK QtNetwork)
+    else ()
+        unset(EXTRA_PACK)
+    endif ()
+
+    find_package(Qt4 COMPONENTS QtCore QtGui QtXml ${EXTRA_PACK})
+
+    if (Qt4_FOUND)
+        set(REQUEST_QT 4)
+    elseif (${REQUEST_QT})
+        message(FATAL_ERROR "The required Qt4 was not found.")
+    endif ()
+endif ()
+
+if (NOT ${REQUEST_QT} OR ${REQUEST_QT} EQUAL 5)
+    if (WITH_NETWORK)
+        set(EXTRA_PACK Network)
+    else ()
+        unset(EXTRA_PACK)
+    endif ()
+
+    find_package(Qt5 COMPONENTS Core PrintSupport Widgets Xml ${EXTRA_PACK})
+
+    if (Qt5_FOUND)
+        set(REQUEST_QT 5)
+    elseif (${REQUEST_QT})
+        message(FATAL_ERROR "The required Qt5 was not found.")
+    endif ()
+endif ()
+
+if (NOT ${REQUEST_QT} OR ${REQUEST_QT} EQUAL 6)
+    if (WITH_NETWORK)
+        set(EXTRA_PACK Network)
+    else ()
+        unset(EXTRA_PACK)
+    endif ()
+
+    find_package(Qt6 COMPONENTS Core PrintSupport Widgets Xml Core5Compat ${EXTRA_PACK})
+
+    if (Qt6_FOUND)
+        set(REQUEST_QT 6)
+    elseif (${REQUEST_QT})
+        message(FATAL_ERROR "The required Qt6 was not found.")
+    endif ()
+endif ()
+
+if (NOT ${REQUEST_QT})
+    message(FATAL_ERROR "No suitable version of Qt was found.")
+endif ()
+
+set(QT Qt${REQUEST_QT})
+message("-- Used Qt version: ${REQUEST_QT}")
+
+
+# Aliases for Qt libraries for easy use regardless of version.
+################################################################################
+
+macro(qt_aliase)
+    if(NOT TARGET Qt::${ARGV0})
+        if (${REQUEST_QT} EQUAL 4)
+            set(_lib ${ARGV1})
+        else ()
+            set(_lib ${ARGV0})
+        endif ()
+
+        if (TARGET ${QT}::${_lib})
+            add_library(Qt::${ARGV0} ALIAS ${QT}::${_lib})
+        else ()
+            message(WARNING "the ${QT}::${_lib} lib not found")
+        endif ()
+    endif()
+endmacro()
+
+qt_aliase(Core QtCore)
+qt_aliase(PrintSupport QtGui)
+qt_aliase(Widgets QtGui)
+qt_aliase(Xml QtXml)
+
+if (WITH_NETWORK)
+    qt_aliase(Network QtNetwork)
+endif ()
+
+
+# The location of the installation directories. Only relative paths may be used.
+#
+#       Common:
+#
+# APP_BIN_PATH    directory to install executable.
+# APP_I18N_PATH   directory to install translations.
+# APP_DOC_PATH    directory to install documentation.
+# APP_IMG_PATH    directory to install application icons.
+#
+#       System-specific:
+#
+# APP_DSK_PATH    installation directory for a desktop entry in GNU/Linux.
+#
+# From https://cmake.org/cmake/help/latest/command/install.html
+#
+# As absolute paths are not supported by cpack installer generators, it is
+# preferable to use relative paths throughout. In particular, there is no need
+# to make paths absolute by prepending CMAKE_INSTALL_PREFIX; this prefix is
+# used by default if the DESTINATION is a relative path.
+################################################################################
+
+if (${CMAKE_SYSTEM_NAME}  MATCHES "Windows")
+    set(APP_ROOT_PATH doublecontact)
+    set(APP_BIN_PATH  ${APP_ROOT_PATH})
+    set(APP_I18N_PATH ${APP_ROOT_PATH})
+    set(APP_IMG_PATH  ${APP_ROOT_PATH})
+    set(APP_DOC_PATH  ${APP_ROOT_PATH}/doc)
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+else ()
+    set(APP_BIN_PATH  bin)
+    set(APP_I18N_PATH share/doublecontact/translations)
+    set(APP_DSK_PATH  share/applications)
+    set(APP_IMG_PATH  share/pixmaps)
+    set(APP_DOC_PATH  share/doc/doublecontact)
+endif ()
+
+
+# Run in those subdirectories
+################################################################################
+
+add_subdirectory(3rdparty)
+add_subdirectory(app)
+add_subdirectory(contconv)
+add_subdirectory(core)
+add_subdirectory(img)
+add_subdirectory(model)
+add_subdirectory(translations)
+
+
+# Install documentation.
+################################################################################
+
+file(GLOB APP_DOC_FILES LIST_DIRECTORIES FALSE ./COPYING ./README.md doc/*.*)
+install(FILES ${APP_DOC_FILES} DESTINATION ${APP_DOC_PATH})
+
+
+# Settings for packers.
+# Currently only DEB is supported
+################################################################################
+
+# https://cmake.org/cmake/help/latest/cpack_gen/deb.html
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Mikhail Y. Zvyozdochkin")
+set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "Offline DE-independent contact manager")
+set(CPACK_DEBIAN_PACKAGE_SECTION "misc")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+
+include (CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,12 +143,11 @@ endif ()
 # used by default if the DESTINATION is a relative path.
 ################################################################################
 
-if (${CMAKE_SYSTEM_NAME}  MATCHES "Windows")
-    set(APP_ROOT_PATH doublecontact)
-    set(APP_BIN_PATH  ${APP_ROOT_PATH})
-    set(APP_I18N_PATH ${APP_ROOT_PATH})
-    set(APP_IMG_PATH  ${APP_ROOT_PATH})
-    set(APP_DOC_PATH  ${APP_ROOT_PATH}/doc)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    set(APP_BIN_PATH  ".")
+    set(APP_I18N_PATH ".")
+    set(APP_IMG_PATH  ".")
+    set(APP_DOC_PATH  doc)
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 else ()
     set(APP_BIN_PATH  bin)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,44 +1,96 @@
-project(doublecontact CXX)
 
-# Problems:
-# compiled file much more than qmake build
-# neet parametrised generator for cpack (DEB or RPM, etc. without this file editing)
-# project must support both Qt4 and Qt5
-# need project for doublecontact and contconv and root project for packaging
+cmake_minimum_required (VERSION 3.5)
 
-message ("cmake build still not work correctly, use qmake")
+project(DoubleContactApp LANGUAGES CXX)
 
-cmake_minimum_required ( VERSION 2.8.9 )
-add_definitions(-Wall -g)
-find_package(Qt4 COMPONENTS QtCore QtGui QtXml REQUIRED)
+add_executable(doublecontact)
+set_target_properties(doublecontact PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON)
+target_link_libraries(doublecontact Qt::Core Qt::Widgets Qt::Xml quazip_static S_CORE S_MODEL)
 
-set(SOURCES main.cpp mainwindow.cpp contactdialog.cpp phonetypedialog.cpp logwindow.cpp settingsdialog.cpp datedetailsdialog.cpp helpers.cpp comparecontainers.cpp comparedialog.cpp multicontactdialog.cpp aboutdialog.cpp languageselectdialog.cpp)
-set(UIS mainwindow.ui contactdialog.ui phonetypedialog.ui logwindow.ui settingsdialog.ui datedetailsdialog.ui comparedialog.ui multicontactdialog.ui aboutdialog.ui languageselectdialog.ui)
-set(CMAKE_AUTOMOC true)
-# Need for old cmake
-IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} LESS 3.0)
-    set(MOC_HEADERS ../model/contactmodel.h)
-ENDIF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} LESS 3.0)
+install(TARGETS doublecontact DESTINATION ${APP_BIN_PATH})
+install(FILES doublecontact.desktop DESTINATION ${APP_DSK_PATH})
 
- include_directories(
-  ${CMAKE_BINARY_DIR} ${QT_INCLUDE_DIR} ${QT_INCLUDE_DIR}/QtCore ${QT_INCLUDE_DIR}/QtGui ${QT_INCLUDE_DIR}/QtXml
- ../core ../model)
-add_subdirectory(../core "${CMAKE_CURRENT_BINARY_DIR}/core")
-add_subdirectory(../model "${CMAKE_CURRENT_BINARY_DIR}/model")
+target_sources(doublecontact
+    PRIVATE
+    # HEADERS
+    ################
+        mainwindow.h
+        contactdialog.h
+        phonetypedialog.h
+        logwindow.h
+        settingsdialog.h
+        datedetailsdialog.h
+        helpers.h
+        comparecontainers.h
+        comparedialog.h
+        innerfilewindow.h
+        multicontactdialog.h
+        aboutdialog.h
+        languageselectdialog.h
+        csvprofiledialog.h
+        sortdialog.h
+        tagremovedialog.h
+        groupdialog.h
+    # SOURCES
+    ################
+        main.cpp
+        mainwindow.cpp
+        contactdialog.cpp
+        phonetypedialog.cpp
+        logwindow.cpp
+        settingsdialog.cpp
+        datedetailsdialog.cpp
+        helpers.cpp
+        comparecontainers.cpp
+        comparedialog.cpp
+        innerfilewindow.cpp
+        multicontactdialog.cpp
+        aboutdialog.cpp
+        languageselectdialog.cpp
+        csvprofiledialog.cpp
+        sortdialog.cpp
+        tagremovedialog.cpp
+        groupdialog.cpp
+    # FORMS
+    ################
+        mainwindow.ui
+        contactdialog.ui
+        phonetypedialog.ui
+        logwindow.ui
+        settingsdialog.ui
+        datedetailsdialog.ui
+        comparedialog.ui
+        multicontactdialog.ui
+        aboutdialog.ui
+        languageselectdialog.ui
+    # RESOURCES
+    ################
+        doublecontact.qrc
+)
 
-include(${QT_USE_FILE})
-qt4_wrap_ui(UI_HEADERS ${UIS})
-qt4_wrap_cpp(MOC_SRCS ${MOC_HEADERS})
+if (WITH_CALLS)
+    target_compile_definitions(doublecontact PRIVATE WITH_CALLS)
+    target_sources(doublecontact
+        PRIVATE
+            callwindow.h
+            callwindow.cpp
+            callwindow.ui
+    )
+endif ()
 
-set(TR_DIR ../translations)
-set(TS_FILES ${TR_DIR}/doublecontact_ru_RU.ts ${TR_DIR}/doublecontact_en_GB.ts)
-qt4_add_translation(qm_files ${TS_FILES})
+if (WITH_MESSAGES)
+    target_compile_definitions(doublecontact PRIVATE WITH_MESSAGES)
+    target_sources(doublecontact
+        PRIVATE
+            messagewindow.h
+            messagewindow.cpp
+            messagewindow.ui
+    )
+endif ()
 
-add_executable(doublecontact ${SOURCES} $<TARGET_OBJECTS:S_CORE> $<TARGET_OBJECTS:S_MODEL> ${UI_HEADERS} ${MOC_SRCS} ${qm_files})
-target_link_libraries(doublecontact ${QT_LIBRARIES})
-
-set(CPACK_DEBIAN_PACKAGE_MAINTAINER Mikhail Y. Zvyozdochkin)
-set(CPACK_GENERATOR DEB)
-install(TARGETS doublecontact DESTINATION doublecontact)
-install(FILES ${qm_files} DESTINATION doublecontact)
-include (CPack)
+if (${CMAKE_SYSTEM_NAME}  MATCHES "Windows")
+    target_sources(doublecontact
+        PRIVATE
+            doublecontact.rc
+    )
+endif ()

--- a/cmake/modules/Findlibzip.cmake
+++ b/cmake/modules/Findlibzip.cmake
@@ -1,0 +1,30 @@
+# Tries to find libzip
+
+cmake_minimum_required(VERSION 3.5)
+
+find_path(libzip_INCLUDE_DIR NAMES zip.h
+    PATHS ${libzip_ROOT}
+    PATH_SUFFIXES libzip/include include)
+
+find_library(libzip_LIBRARY NAMES zip
+    PATHS ${libzip_ROOT}
+    PATH_SUFFIXES libzip/lib lib)
+
+if (libzip_INCLUDE_DIR AND libzip_LIBRARY)
+   set(libzip_FOUND TRUE)
+endif ()
+
+
+if (libzip_FOUND)
+   if (NOT libzip_FIND_QUIETLY)
+      message(STATUS "Found libzip: ${libzip_LIBRARY}")
+   endif ()
+
+   add_library(libzip::zip INTERFACE IMPORTED GLOBAL)
+   set_target_properties(libzip::zip PROPERTIES
+         INTERFACE_INCLUDE_DIRECTORIES ${libzip_INCLUDE_DIR}
+         INTERFACE_LINK_LIBRARIES ${libzip_LIBRARY}
+   )
+elseif (libzip_FIND_REQUIRED)
+      message(FATAL_ERROR "Could not find libzip. Please install libzip and libzip-devel packages.")
+endif ()

--- a/contconv/CMakeLists.txt
+++ b/contconv/CMakeLists.txt
@@ -1,0 +1,23 @@
+
+cmake_minimum_required (VERSION 3.5)
+
+project(ContConv LANGUAGES CXX)
+
+add_executable(contconv)
+set_target_properties(contconv PROPERTIES AUTOMOC ON)
+target_link_libraries(contconv Qt::Core S_CORE)
+
+install(TARGETS contconv DESTINATION ${APP_BIN_PATH})
+
+target_sources(contconv
+    PRIVATE
+    # HEADERS
+    ################
+        convertor.h
+        consoleasyncui.h
+    # SOURCES
+    ################
+        main.cpp
+        convertor.cpp
+        consoleasyncui.cpp
+)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,13 +1,111 @@
-add_library(S_CORE OBJECT
- contactlist.cpp
- globals.cpp
- languagemanager.cpp
- formats/formatfactory.cpp
- formats/common/vcarddata.cpp
- formats/files/csvfile.cpp
- formats/files/fileformat.cpp
- formats/files/mpbfile.cpp
- formats/files/udxfile.cpp
- formats/files/vcfdirectory.cpp
- formats/files/vcffile.cpp
+# Core (GUI-independent) part of DoubleContact
+#
+# To use code under GPLv2, switch on USE_GPL2 define.
+# NBU support will be disabled
+
+cmake_minimum_required(VERSION 3.5)
+
+add_library(S_CORE STATIC)
+set_target_properties(S_CORE PROPERTIES AUTOMOC ON)
+target_link_libraries(S_CORE PUBLIC Qt::Core Qt::Xml quazip_static)
+target_include_directories(S_CORE PUBLIC .)
+
+target_sources(S_CORE
+    PRIVATE
+    # HEADERS
+    ################
+        bstring.h
+        contactlist.h
+        corehelpers.h
+        extra.h
+        globals.h
+        languagemanager.h
+        formats/iformat.h
+        formats/formatfactory.h
+        formats/common/quotedprintable.h
+        formats/common/textreport.h
+        formats/common/vcarddata.h
+        formats/common/vdata.h
+        formats/files/csvfile.h
+        formats/files/fileformat.h
+        formats/files/htmlfile.h
+        formats/files/mpbfile.h
+        formats/files/nbffile.h
+        formats/files/udxfile.h
+        formats/files/vcfdirectory.h
+        formats/files/vcffile.h
+        formats/files/xmlcontactfile.h
+        formats/network/asyncformat.h
+        formats/profiles/csvprofilebase.h
+        formats/profiles/explaybm50profile.h
+        formats/profiles/explaytv240profile.h
+        formats/profiles/genericcsvprofile.h
+        formats/profiles/osmoprofile.h
+        formats/profiles/sylpheedprofile.h
+    # SOURCES
+    ################
+        bstring.cpp
+        contactlist.cpp
+        corehelpers.cpp
+        extra.cpp
+        globals.cpp
+        languagemanager.cpp
+        formats/formatfactory.cpp
+        formats/common/quotedprintable.cpp
+        formats/common/textreport.cpp
+        formats/common/vcarddata.cpp
+        formats/common/vdata.cpp
+        formats/files/csvfile.cpp
+        formats/files/fileformat.cpp
+        formats/files/htmlfile.cpp
+        formats/files/mpbfile.cpp
+        formats/files/nbffile.cpp
+        formats/files/udxfile.cpp
+        formats/files/vcfdirectory.cpp
+        formats/files/vcffile.cpp
+        formats/files/xmlcontactfile.cpp
+        formats/network/asyncformat.cpp
+        formats/profiles/csvprofilebase.cpp
+        formats/profiles/explaybm50profile.cpp
+        formats/profiles/explaytv240profile.cpp
+        formats/profiles/genericcsvprofile.cpp
+        formats/profiles/osmoprofile.cpp
+        formats/profiles/sylpheedprofile.cpp
 )
+
+if (WITH_CALLS)
+    target_compile_definitions(S_CORE PRIVATE WITH_CALLS)
+endif ()
+
+if (WITH_MESSAGES)
+    target_compile_definitions(S_CORE PRIVATE WITH_MESSAGES)
+    target_sources(S_CORE
+        PRIVATE
+        # HEADERS
+        ################
+            decodedmessagelist.h
+            formats/common/nokiadata.h
+            formats/common/pdu.h
+            formats/common/vmessagedata.h
+        # SOURCES
+        ################
+            decodedmessagelist.cpp
+            formats/common/nokiadata.cpp
+            formats/common/pdu.cpp
+            formats/common/vmessagedata.cpp
+    )
+endif ()
+
+if (USE_GPL2)
+    target_compile_definitions(S_CORE PRIVATE USE_GPL2)
+else ()
+    target_sources(S_CORE
+        PRIVATE
+        # HEADERS
+        ################
+            formats/files/nbufile.h
+        # SOURCES
+        ################
+            formats/files/nbufile.cpp
+    )
+endif ()

--- a/img/CMakeLists.txt
+++ b/img/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+cmake_minimum_required(VERSION 3.5)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    install(FILES uchmviewer.png DESTINATION ${APP_ICONS_INSTALL_DIR})
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    install(
+    FILES
+        32x32/doublecontact_32x32.xpm
+    DESTINATION ${APP_IMG_PATH})
+elseif (&{CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    install(
+    FILES
+        32x32/doublecontact_32x32.png
+    DESTINATION ${APP_IMG_PATH})
+endif ()

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -1,5 +1,44 @@
-add_library(S_MODEL OBJECT
- contactmodel.cpp
- contactsorterfilter.cpp
- recentlist.cpp
- configmanager.cpp)
+# Model-related part of DoubleContact
+
+cmake_minimum_required(VERSION 3.5)
+
+add_library(S_MODEL STATIC)
+set_target_properties(S_MODEL PROPERTIES AUTOMOC ON)
+target_link_libraries(S_MODEL PUBLIC Qt::Core Qt::Widgets S_CORE)
+target_include_directories(S_MODEL PUBLIC .)
+
+target_sources(S_MODEL
+    PRIVATE
+    # HEADERS
+    ################
+        contactmodel.h
+        innerfilemodel.h
+        modelhelpers.h
+        recentlist.h
+        configmanager.h
+    # SOURCES
+    ################
+        contactmodel.cpp
+        innerfilemodel.cpp
+        modelhelpers.cpp
+        recentlist.cpp
+        configmanager.cpp
+)
+
+if (WITH_CALLS)
+    target_compile_definitions(S_MODEL PRIVATE WITH_CALLS)
+    target_sources(S_MODEL
+        PRIVATE
+            callmodel.h
+            callmodel.cpp
+    )
+endif ()
+
+if (WITH_MESSAGES)
+    target_compile_definitions(S_MODEL PRIVATE WITH_MESSAGES)
+    target_sources(S_MODEL
+        PRIVATE
+            messagemodel.h
+            messagemodel.cpp
+    )
+endif ()

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Create and install translation files.
+
+cmake_minimum_required(VERSION 3.5)
+
+set(LANGUAGES de en_GB fr ie nb_NO nl pl pt pt_BR ru_RU uk_UA zh_Hant)
+
+foreach (LANG ${LANGUAGES})
+    set(TS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/doublecontact_${LANG}.ts)
+    set(QM_FILE ${CMAKE_CURRENT_BINARY_DIR}/doublecontact_${LANG}.qm)
+    list(APPEND QM_LIST ${QM_FILE})
+    add_custom_command(OUTPUT ${QM_FILE}
+        COMMAND lrelease -silent ${TS_FILE} -qm ${QM_FILE}
+        DEPENDS ${TS_FILE}
+        COMMENT "Generate doublecontact_${LANG}.qm")
+    install(FILES ${QM_FILE} DESTINATION ${APP_I18N_PATH})
+endforeach ()
+
+add_custom_target(translations ALL DEPENDS ${QM_LIST})

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -2,6 +2,15 @@
 
 cmake_minimum_required(VERSION 3.5)
 
+find_program (LRELEASE_EXE lrelease)
+
+if (LRELEASE_EXE)
+    message("-- Found lrelease")
+else ()
+    message(WARNING "The lrelease was not found. Generation of translations will be skipped.")
+    return()
+endif ()
+
 set(LANGUAGES de en_GB fr ie nb_NO nl pl pt pt_BR ru_RU uk_UA zh_Hant)
 
 foreach (LANG ${LANGUAGES})
@@ -9,10 +18,13 @@ foreach (LANG ${LANGUAGES})
     set(QM_FILE ${CMAKE_CURRENT_BINARY_DIR}/doublecontact_${LANG}.qm)
     list(APPEND QM_LIST ${QM_FILE})
     add_custom_command(OUTPUT ${QM_FILE}
-        COMMAND lrelease -silent ${TS_FILE} -qm ${QM_FILE}
+        COMMAND ${LRELEASE_EXE} -silent ${TS_FILE} -qm ${QM_FILE}
         DEPENDS ${TS_FILE}
         COMMENT "Generate doublecontact_${LANG}.qm")
     install(FILES ${QM_FILE} DESTINATION ${APP_I18N_PATH})
 endforeach ()
 
 add_custom_target(translations ALL DEPENDS ${QM_LIST})
+install(FILES iso639-1.utf8 DESTINATION ${APP_I18N_PATH})
+# Needed for localisation when application is launched from the build directory.
+file(COPY_FILE iso639-1.utf8 ${CMAKE_CURRENT_BINARY_DIR}/iso639-1.utf8)


### PR DESCRIPTION
The update allows you to build your application with Qt4, Qt5 or Qt6 as your choice. The options correspond to those of the Qmake project, including the experimental `WITH_NETWORK`. `*.qm` translation files are generated. For Windows and Linux, the directories for installing components are defined as in `pack/make-bin-image` files.

The script is not able to update `*.ts` translation files.