### PR TITLE
Add Qt6 support

### DIFF
--- a/3rdparty/quazip/quazip/JlCompress.cpp
+++ b/3rdparty/quazip/quazip/JlCompress.cpp
@@ -255,7 +255,7 @@ bool JlCompress::compressFiles(QString fileCompressed, QStringList files) {
 }
 
 bool JlCompress::compressDir(QString fileCompressed, QString dir, bool recursive) {
-    return compressDir(fileCompressed, dir, recursive, 0);
+    return compressDir(fileCompressed, dir, recursive, QDir::Filters());
 }
 
 bool JlCompress::compressDir(QString fileCompressed, QString dir,

--- a/3rdparty/quazip/quazip/quagzipfile.cpp
+++ b/3rdparty/quazip/quazip/quagzipfile.cpp
@@ -57,13 +57,13 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
     char modeString[2];
     modeString[0] = modeString[1] = '\0';
     if ((mode & QIODevice::Append) != 0) {
-        error = QuaGzipFile::trUtf8("QIODevice::Append is not "
+        error = QuaGzipFile::tr("QIODevice::Append is not "
                 "supported for GZIP");
         return false;
     }
     if ((mode & QIODevice::ReadOnly) != 0
             && (mode & QIODevice::WriteOnly) != 0) {
-        error = QuaGzipFile::trUtf8("Opening gzip for both reading"
+        error = QuaGzipFile::tr("Opening gzip for both reading"
             " and writing is not supported");
         return false;
     } else if ((mode & QIODevice::ReadOnly) != 0) {
@@ -71,13 +71,13 @@ bool QuaGzipFilePrivate::open(FileId id, QIODevice::OpenMode mode,
     } else if ((mode & QIODevice::WriteOnly) != 0) {
         modeString[0] = 'w';
     } else {
-        error = QuaGzipFile::trUtf8("You can open a gzip either for reading"
+        error = QuaGzipFile::tr("You can open a gzip either for reading"
             " or for writing. Which is it?");
         return false;
     }
     gzd = open(id, modeString);
     if (gzd == NULL) {
-        error = QuaGzipFile::trUtf8("Could not gzopen() file");
+        error = QuaGzipFile::tr("Could not gzopen() file");
         return false;
     }
     return true;

--- a/3rdparty/quazip/quazip/quaziodevice.cpp
+++ b/3rdparty/quazip/quazip/quaziodevice.cpp
@@ -144,12 +144,12 @@ QIODevice *QuaZIODevice::getIoDevice() const
 bool QuaZIODevice::open(QIODevice::OpenMode mode)
 {
     if ((mode & QIODevice::Append) != 0) {
-        setErrorString(trUtf8("QIODevice::Append is not supported for"
+        setErrorString(tr("QIODevice::Append is not supported for"
                     " QuaZIODevice"));
         return false;
     }
     if ((mode & QIODevice::ReadWrite) == QIODevice::ReadWrite) {
-        setErrorString(trUtf8("QIODevice::ReadWrite is not supported for"
+        setErrorString(tr("QIODevice::ReadWrite is not supported for"
                     " QuaZIODevice"));
         return false;
     }

--- a/3rdparty/quazip/quazip/quazipdir.cpp
+++ b/3rdparty/quazip/quazip/quazipdir.cpp
@@ -27,6 +27,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 #include <algorithm>
 #include <QSet>
 #include <QSharedData>
+#include <QtGlobal>     // QT_VERSION QT_VERSION_CHECK
 
 /// \cond internal
 class QuaZipDirPrivate: public QSharedData {
@@ -104,7 +105,11 @@ bool QuaZipDir::cd(const QString &directoryName)
             if (!dir.cd("/"))
                 return false;
         }
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QStringList path = dirName.split('/', Qt::SkipEmptyParts);
+#else
         QStringList path = dirName.split('/', QString::SkipEmptyParts);
+#endif
         for (QStringList::const_iterator i = path.constBegin();
                 i != path.end();
                 ++i) {

--- a/3rdparty/quazip/quazip/quazipfileinfo.cpp
+++ b/3rdparty/quazip/quazip/quazipfileinfo.cpp
@@ -26,7 +26,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 
 static QFile::Permissions permissionsFromExternalAttr(quint32 externalAttr) {
     quint32 uPerm = (externalAttr & 0xFFFF0000u) >> 16;
-    QFile::Permissions perm = 0;
+    QFile::Permissions perm = QFile::Permissions();
     if ((uPerm & 0400) != 0)
         perm |= QFile::ReadOwner;
     if ((uPerm & 0200) != 0)

--- a/3rdparty/quazip/quazip/quazipnewinfo.cpp
+++ b/3rdparty/quazip/quazip/quazipnewinfo.cpp
@@ -23,6 +23,7 @@ see quazip/(un)zip.h files for details. Basically it's the zlib license.
 */
 
 #include <QFileInfo>
+#include <QtGlobal>     // QT_VERSION QT_VERSION_CHECK
 
 #include "quazipnewinfo.h"
 
@@ -134,7 +135,11 @@ void QuaZipNewInfo::setFileNTFSTimes(const QString &fileName)
     }
     setFileNTFSmTime(fi.lastModified());
     setFileNTFSaTime(fi.lastRead());
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    setFileNTFScTime(fi.birthTime());
+#else
     setFileNTFScTime(fi.created());
+#endif
 }
 
 static void setNTFSTime(QByteArray &extra, const QDateTime &time, int position,

--- a/app/doublecontact.pro
+++ b/app/doublecontact.pro
@@ -8,6 +8,7 @@ include(../model/model.pri)
 
 QT += gui
 greaterThan(QT_MAJOR_VERSION, 4):QT += widgets
+greaterThan(QT_MAJOR_VERSION, 5): QT += core5compat
 
 TARGET = doublecontact
 TEMPLATE = app

--- a/contconv/contconv.pro
+++ b/contconv/contconv.pro
@@ -6,6 +6,7 @@
 
     QT       += core
     QT       -= gui
+    greaterThan(QT_MAJOR_VERSION, 5): QT += core5compat
     DEFINES -= WITH_NETWORK
     include(../core/core.pri)
 

--- a/core/contactlist.cpp
+++ b/core/contactlist.cpp
@@ -442,7 +442,7 @@ void ContactItem::parseFullName()
         names.removeLast();
     for (int i=0; i<names.count(); i++)
         if (names[i].right(1)==",")
-            names[i].remove(names[i].count()-1);
+            names[i].remove(names[i].count()-1, 1);
 }
 
 void ContactItem::reverseFullName()

--- a/core/decodedmessagelist.cpp
+++ b/core/decodedmessagelist.cpp
@@ -95,7 +95,11 @@ bool DecodedMessageList::toCSV(const QString &path)
     if (!f.open(QIODevice::WriteOnly))
         return false;
     QTextStream ss(&f);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // https://doc.qt.io/qt-6/qtextstream.html#setEncoding
+    // In Qt6 by default UTF-8 is used.
     ss.setCodec("UTF-8");
+#endif
     ss << QObject::tr("\"Date\",\"Box\",\"From/To\",\"Number\",\"Status\",\"Text\",\"Aux\"\n");
     foreach(const DecodedMessage& msg, *this) {
         // Stricted text, without qoutes and line breaks

--- a/core/formats/common/nokiadata.cpp
+++ b/core/formats/common/nokiadata.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <limits.h>
+#include <QIODevice>
 #include <QTextCodec>
 
 #include "nokiadata.h"

--- a/core/formats/common/quotedprintable.cpp
+++ b/core/formats/common/quotedprintable.cpp
@@ -82,9 +82,9 @@ BString QuotedPrintable::encode(const QString &src, QTextCodec *codec, int prefi
         QByteArray bytes = codec->fromUnicode(ch);
         // Can we use Literal representation?
         // Rule 2 (RFC 2045). Literal representation
-        bool useLiteral = (ch>=33 && ch<=126 && ch!=61);
+        bool useLiteral = (ch>=QChar(33) && ch<=QChar(126) && ch!=QChar(61));
         // Rule 3. Spaces
-        if (ch==0x20 || ch==0x09)
+        if (ch==QChar(0x20) || ch==QChar(0x09))
             useLiteral = i<src.count()-1;
         // Represent!
         bool lastChar = i==src.count()-1;

--- a/core/formats/files/htmlfile.cpp
+++ b/core/formats/files/htmlfile.cpp
@@ -41,7 +41,11 @@ bool HTMLFile::exportRecords(const QString &url, ContactList &list)
         return false;
     _errors.clear();
     QTextStream stream(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // https://doc.qt.io/qt-6/qtextstream.html#setEncoding
+    // In Qt6 by default UTF-8 is used.
     stream.setCodec("UTF-8");
+#endif    
     stream << QString("<html><head>\n<meta charset=\"utf-8\">\n<title>%1</title>\n</head>\n<body>").arg(url) << ENDL;
     // General data
     stream << QString("<b>%1</b>: %2<br/>\n").arg(S_ADDRESS_BOOK).arg(url);

--- a/core/formats/files/udxfile.cpp
+++ b/core/formats/files/udxfile.cpp
@@ -315,7 +315,11 @@ bool UDXFile::exportRecords(const QString &url, ContactList &list)
     if (!openFile(url, QIODevice::WriteOnly))
         return false;
     QTextStream stream(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // https://doc.qt.io/qt-6/qtextstream.html#setEncoding
+    // In Qt6 by default UTF-8 is used.
     stream.setCodec("UTF-8");
+#endif    
     stream << content;
     closeFile();
     return true;

--- a/core/languagemanager.cpp
+++ b/core/languagemanager.cpp
@@ -15,8 +15,16 @@
 #include <QDir>
 #include <QFile>
 #include <QLocale>
-#include <QRegExp>
 #include <QTextCodec>
+#include <QtGlobal>         // QT_VERSION QT_VERSION_CHECK
+
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    #include <QRegularExpression>
+    #define QRegExp QRegularExpression
+#else
+    #include <QRegExp>
+#endif
+
 #include "languagemanager.h"
 #include "corehelpers.h"
 

--- a/model/callmodel.cpp
+++ b/model/callmodel.cpp
@@ -98,7 +98,11 @@ bool CallModel::saveToCSV(const QString &path)
     if (!f.open(QIODevice::WriteOnly))
         return false;
     QTextStream ss(&f);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    // https://doc.qt.io/qt-6/qtextstream.html#setEncoding
+    // In Qt6 by default UTF-8 is used.
     ss.setCodec("UTF-8");
+#endif
     ss << QObject::tr("\"Type\",\"Date\",\"Duration\",\"Number\",\"Name\"\n");
     foreach(const CallInfo& c, _src->extra.calls) {
         ss << "\""    << c.typeName()

--- a/model/configmanager.cpp
+++ b/model/configmanager.cpp
@@ -48,7 +48,13 @@ void ConfigManager::prepare()
     if (!isPortable) {
         delete settings;
         settings = new QSettings("DarkHobbit", "doublecontact");
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        // https://doc.qt.io/qt-6.2/qsettings.html#Format-enum
+        // In line with most implementations today, QSettings will assume the
+        // INI file is utf-8 encoded. This means that keys and values will be
+        // decoded as utf-8 encoded entries and written back as utf-8.
         settings->setIniCodec(QTextCodec::codecForName("UTF-8"));
+#endif
     }
 }
 

--- a/model/recentlist.cpp
+++ b/model/recentlist.cpp
@@ -21,7 +21,13 @@ void RecentList::read()
 {
     clear();
     QSettings settings("DarkHobbit", "doublecontact"); // TODO unify with main config
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        // https://doc.qt.io/qt-6.2/qsettings.html#Format-enum
+        // In line with most implementations today, QSettings will assume the
+        // INI file is utf-8 encoded. This means that keys and values will be
+        // decoded as utf-8 encoded entries and written back as utf-8.
     settings.setIniCodec("UTF8");
+#endif
     int _count = settings.value("Recent/Count", 0).toInt();
     for (int i=1; i<=_count; i++)
         push_back(settings.value(QString("Recent/Item%1").arg(i)).toString());


### PR DESCRIPTION
The patch adds the ability to build with Qt6.

Most of the changes are trivial and cosmetic, but in `core/formats/files/csvfile.cpp` we had to change the way text is encoded when reading/writing files. Also the possibility to write BOM is disabled for now.

The [Core5Compat](https://doc.qt.io/qt-6/qtcore5-index.html) module is required to build with Qt6.